### PR TITLE
Minor fixes for manual data management

### DIFF
--- a/components/charts/IndicatorChart.js
+++ b/components/charts/IndicatorChart.js
@@ -14,7 +14,7 @@ import ChartTypeControls from './controls/ChartTypeControls';
 import IndexesChart from './indexesChart';
 import { hasSomeData } from './helpers/ChartDataHelper';
 import GeoChart from './GeoChart';
-import WealthQuintilleChart from './WealthQuintilleChart';
+import WealthQuintileChart from './WealthQuintileChart';
 
 const ChartContent = styled.div`
   width: 100%;
@@ -293,12 +293,12 @@ const IndicatorChart = ({
   };
 
   const showSocioeconomicLevelTab = () => {
-    if ((tabsToShow.indexOf('wealth-quintille') !== -1)
-        && chartData.visualizations['wealth-quintille'].historical.length > 0
-        && chartData.visualizations['wealth-quintille'].latest.length > 0) {
+    if ((tabsToShow.indexOf('wealth-quintile') !== -1)
+        && chartData.visualizations['wealth-quintile'].historical.length > 0
+        && chartData.visualizations['wealth-quintile'].latest.length > 0) {
       return (
         <Tab eventKey="socioeconomicLevel" title={<TapTitle iconUrl="/img/home/icon_total_line.svg">{t('socioeconomicLevel')}</TapTitle>}>
-          <WealthQuintilleChart data={chartData} chartType={chartType} />
+          <WealthQuintileChart data={chartData} chartType={chartType} />
         </Tab>
       );
     }

--- a/components/charts/WealthQuintileChart.js
+++ b/components/charts/WealthQuintileChart.js
@@ -16,9 +16,9 @@ const Content = styled.div`
   background-color: #FFFFFF;
 `;
 
-const WealthQuintilleChart = ({ data, t, chartType }) => {
-  const [latestData, setLatestData] = useState(charDataFormatHelper(data.visualizations['wealth-quintille'].latest));
-  const [historicalData, setHistoricalData] = useState(charDataFormatHelper(data.visualizations['wealth-quintille'].historical));
+const WealthQuintileChart = ({ data, t, chartType }) => {
+  const [latestData, setLatestData] = useState(charDataFormatHelper(data.visualizations['wealth-quintile'].latest));
+  const [historicalData, setHistoricalData] = useState(charDataFormatHelper(data.visualizations['wealth-quintile'].historical));
   const [chartMetrics, setChartMetrics] = useState(ChartMetrics.LAST_YEAR);
   const datasource = chartMetrics === ChartMetrics.LAST_YEAR ? latestData : historicalData;
 
@@ -98,7 +98,7 @@ const WealthQuintilleChart = ({ data, t, chartType }) => {
   );
 };
 
-WealthQuintilleChart.getInitialProps = ({ t, data, chartType }) => (
+WealthQuintileChart.getInitialProps = ({ t, data, chartType }) => (
   {
     t,
     data,
@@ -107,4 +107,4 @@ WealthQuintilleChart.getInitialProps = ({ t, data, chartType }) => (
   }
 );
 
-export default withTranslation('charts')(WealthQuintilleChart);
+export default withTranslation('charts')(WealthQuintileChart);

--- a/components/layout/IndicatorAdminList.js
+++ b/components/layout/IndicatorAdminList.js
@@ -64,17 +64,15 @@ const IconContainer = styled.div`
 const IndicatorAdminList = ({ indicators, t }) => (
   <>
     {indicators?.map((indicator) => {
-      let indicatorPath = `/admin/data/${indicator.id}`;
-      if (indicator.variation) {
-        indicatorPath += `?variation=${indicator.variation}`;
-      }
+      const indicatorPath = `/admin/data/${indicator.code}`;
+      const indicatorName = indicator.isVariation ? `variations.${indicator.code}` : `indicators.${indicator.code}.metadata.title`;
       return (
-        <Link key={`indicador-${indicator.id}`} href={indicatorPath} as={indicatorPath}>
+        <Link key={`indicador-${indicator.code}`} href={indicatorPath} as={indicatorPath}>
           <Row className="mb-3 p-0">
             <Container className="d-flex flex-row justify-content-between p-0">
               <div className="col-md-11 col-8">
                 <Title>
-                  {t(`indicators.${indicator.id}.metadata.title`)}
+                  {t(indicatorName)}
                 </Title>
               </div>
               <IconContainer className="col-md-1 col-2">

--- a/pages/admin/data/[id]/add.js
+++ b/pages/admin/data/[id]/add.js
@@ -11,11 +11,10 @@ const preventDefault = (f) => (e) => {
 };
 
 const AdminDataNewForm = ({
-  id, user, visualizations, indexes, data, variation,
+  id, user, visualizations, indexes, data, variation, code,
 }) => {
-  const variationQueryParam = variation ? `variation=${variation}` : '';
   const postUrl = `/api/indicators/${id}/manual-data`;
-  const redirectUrl = `/admin/data/${id}?${variationQueryParam}`;
+  const redirectUrl = `/admin/data/${code}`;
 
   const router = useRouter();
   const [formData, setFormData] = useState({});
@@ -49,7 +48,7 @@ const AdminDataNewForm = ({
 };
 
 export const getServerSideProps = needsAuth(async ({ user, query }) => {
-  const { id, variation } = query;
+  const [id, variation] = query.id.split('-');
 
   const variationUrl = (variation) ? `variation=${variation}` : '';
   const url = `${process.env.API_URL}/api/indicators/${id}/manual-data?country=${user.country}&${variationUrl}`;
@@ -64,8 +63,9 @@ export const getServerSideProps = needsAuth(async ({ user, query }) => {
       visualizations: indicator.visualizations,
       indexes: indicator.indexes,
       data: indicator.data,
-      variation,
+      variation: variation || null,
       id,
+      code: query.id,
     },
   });
 });

--- a/pages/admin/data/[id]/edit/[year].js
+++ b/pages/admin/data/[id]/edit/[year].js
@@ -51,7 +51,8 @@ const AdminDataEdit = ({
 };
 
 export const getServerSideProps = needsAuth(async ({ user, query }) => {
-  const { id, year, variation } = query;
+  const { year } = query;
+  const [id, variation] = query.id.split('-');
 
   const variationUrl = (variation) ? `variation=${variation}` : '';
   const url = `${process.env.API_URL}/api/indicators/${id}/manual-data?country=${user.country}&${variationUrl}`;

--- a/pages/admin/data/[id]/index.js
+++ b/pages/admin/data/[id]/index.js
@@ -11,7 +11,7 @@ import FetchUtils from '../../../../utils/Fetch.utils';
 import { Button } from '../../../../components/layout/Button';
 
 const AdminDataDetails = ({
-  t, user, id, visualizations, indexes, data, addDataUrl, country,
+  t, user, id, visualizations, indexes, data, addDataUrl, country, indicatorName,
 }) => (
 
 
@@ -33,7 +33,7 @@ const AdminDataDetails = ({
         }}
         >
           <Title type="caption" textCenter className="mb-4">
-            {t(`indicators.${id}.metadata.title`)}
+            {t(indicatorName)}
           </Title>
 
           <ManualDataTable className="table mt-4 mb-4" visualizations={visualizations} indexes={indexes} data={data} />
@@ -61,7 +61,7 @@ const AdminDataDetails = ({
 );
 
 export const getServerSideProps = needsAuth(async ({ user, query }) => {
-  const { id, variation } = query;
+  const [id, variation] = query.id.split('-');
 
   const variationUrl = (variation) ? `variation=${variation}` : '';
   const indicatorUrl = `${process.env.API_URL}/api/indicators/${id}/manual-data?country=${user.country}&${variationUrl}`;
@@ -69,6 +69,7 @@ export const getServerSideProps = needsAuth(async ({ user, query }) => {
   const [country, indicator] = await FetchUtils.multipleFetch([
     countryUrl, indicatorUrl,
   ]);
+  const indicatorName = (variation) ? `variations.${query.id}` : `indicators.${query.id}.metadata.title`;
 
   return {
     props: {
@@ -78,8 +79,8 @@ export const getServerSideProps = needsAuth(async ({ user, query }) => {
       visualizations: indicator.visualizations,
       indexes: indicator.indexes,
       data: indicator.data,
-      variation,
-      addDataUrl: `/admin/data/${id}/add?${variationUrl}`,
+      indicatorName,
+      addDataUrl: `/admin/data/${query.id}/add`,
       country,
     },
   };

--- a/pages/admin/data/index.js
+++ b/pages/admin/data/index.js
@@ -47,17 +47,16 @@ export const getServerSideProps = needsAuth(async ({ user }) => {
 
   const indicators = [
     {
-      code: '12',
-      variation: 'c',
-      id: '12',
+      code: '12-c',
+      isVariation: true,
     },
     {
       code: '18',
-      id: '18',
+      isVariation: false,
     },
     {
       code: '24',
-      id: '24',
+      isVariation: false,
     },
   ];
 

--- a/pages/api/indicators/[id]/manual-data/index.js
+++ b/pages/api/indicators/[id]/manual-data/index.js
@@ -40,7 +40,6 @@ handler.get(async (req, res) => {
 });
 
 handler.post(async (req, res) => {
-  console.log('post');
   const { id } = req.query;
   if (InputValidatorUtils.validate(inputPostValidator, req.query, res)) {
     await ManualDataService.addData(id, req.body);

--- a/services/ManualData.service.js
+++ b/services/ManualData.service.js
@@ -46,14 +46,31 @@ const indicator12baseData = {
   decimals: 5,
 };
 
-const getBaseData = (id, data) => {
-  const baseData = {};
+const sdgManualBaseData = {
+  unit_measure: 'PT',
+  edu_level: '_T',
+  sex: '_T',
+  age: '_T',
+  grade: '_T',
+  edu_attain: '_Z',
+  subject: '_T',
+  wealth_quintile: '_Z',
+  infrastr: '_Z',
+  location: '_T',
+  unit_mult: 0,
+  obs_status: 'A',
+  freq: 'A',
+  decimals: 5,
+};
+
+const getBaseData = (id, data, query) => {
+  const contextData = { ref_area: data.country, time_period: data.year, ...query };
 
   if (id === 12) {
-    return Object.assign(indicator12baseData, { ref_area: data.country, time_period: data.year });
+    return Object.assign(indicator12baseData, contextData);
   }
 
-  return baseData;
+  return Object.assign(sdgManualBaseData, contextData);
 };
 
 const addIndicatorData = async (id, data) => {
@@ -61,7 +78,7 @@ const addIndicatorData = async (id, data) => {
   const indexesPromise = IndicatorIndexService.findByIndicatorId(id);
   const [indicator, indexes] = await Promise.all([indicatorPromise, indexesPromise]);
 
-  const baseData = getBaseData(indicator.id, data);
+  const baseData = getBaseData(indicator.id, data, indicator.query);
   const insertData = [{ ...baseData, obs_value: data.total }];
   if (data.male && data.female) {
     insertData.push({ ...baseData, sex: MALE_VALUE, obs_value: data.male });


### PR DESCRIPTION
Cambié un par de cosas para que los URLs se manejen con solo un código compuesto del id y el variation en vez de manejar el variation como query param.
De `/admin/data/12?variation=c` a `/admin/data/12-c`
Además de un par de cambios para que muestre el nombre de la variación y no del indicador en caso de que aplique.